### PR TITLE
Change highlight to text rendition and fix completion of words spanned across several lines

### DIFF
--- a/autocomplete-ALL-the-things
+++ b/autocomplete-ALL-the-things
@@ -179,14 +179,14 @@ sub highlight_match {
     my ($el, $ec) = $line->coord_of($+[0]);
 
     $self->{highlight} = [$sl, $sc, $el, $ec];
-
-    $self->want_refresh();
 }
 
 sub on_refresh_begin {
     my ($self) = @_;
 
-    if (!$self->{highlighted} && $self->{highlight}) {
+    clear_highlight($self);
+
+    if ($self->{highlight}) {
         my ($sl, $sc, $el, $ec) = @{$self->{highlight}};
         $self->scr_xor_span($sl, $sc, $el, $ec, urxvt::RS_RVid);
 
@@ -225,9 +225,9 @@ sub find_match {
     my $i;
     # search through all the rows starting with current one or one above the last checked
     for ($i = $current_row; $i >= 0; --$i) {
-        my $line = $self->ROW_t($i);   # get the line of text from the row
+        my $line = $self->line($i);   # get the line of text from the row
 
-        $_ = $line;
+        $_ = $line->t;
 
         # find all the matches in the current line
         my $match;
@@ -239,7 +239,7 @@ sub find_match {
                                                                          )
                                                                      /ix;
         # corner case: match at the very beginning of line
-        push @{$self->{matches_in_row}}, $1 if $line =~ /^($regexp$word_char*)/i;
+        push @{$self->{matches_in_row}}, $1 if $line->t =~ /^($regexp$word_char*)/i;
 
         if (@{$self->{matches_in_row}}) {
             # remember which row should be searched next


### PR DESCRIPTION
I've back on line, sorry for bothering you again. :innocent:

Current overlay implementation does not look too good for me, because it is simple black text on grayish background. I've changed it to XOR text rendition to get visualization same as selection. Now it basically uses reversed video style, which is better in any case and text color.

Also, I've found, that word on the boundary of two lines get's completed only partially, so I fixed it.

Alas, also I've noticed, that when completed word can not fit into one line on the prompt, then all buffer got scrolled up by one line to found some empty space on the bottom of the window to fit this too long line. It worked around by the shell automatically. And in that case highlight will mismatch actual text placement by one or several lines. I did not fix this issue because I didn't found beautiful and not too cluttered solution, so I just left things as they are. Maybe we should create issue for this.
