### PR TITLE
Fixes for urxvt 9.21

### DIFF
--- a/autocomplete-ALL-the-things
+++ b/autocomplete-ALL-the-things
@@ -16,6 +16,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>. #
 #########################################################################
 
+sub on_action {
+    my ($self, $action) = @_;
+
+    on_user_command($self, "aAtt:" . $action);
+}
 
 sub on_user_command {
     my ($self, $cmd) = @_;
@@ -138,7 +143,8 @@ sub conditional_leave {
     my ($self, $event, $keysym) = @_;
 
     my $keyname = $self->XKeysymToString($keysym);
-    if ($keysym <= 127 ||       # if ASCII, ignore ctrl etc.
+    # if ASCII, ignore ctrl etc.
+    if (($event->{'state'} < 2 && $keysym <= 127) ||
         $keyname eq "Return" ||
         $keyname eq "BackSpace" ||
         $keyname eq "Delete" ||
@@ -170,8 +176,11 @@ sub highlight_match {
     my ($beg_row, $beg_col) = $line->coord_of($-[0]);
     my ($end_row, $end_col) = $line->coord_of($+[0]);
 
-    $self->{highlight} = [$beg_row, $beg_col, $end_row, $end_col];
     $self->enable(refresh_begin => sub {
+                      if (exists $self->{highlight}) {
+                          clear_highlight($self);
+                      }
+                      $self->{highlight} = [$beg_row, $beg_col, $end_row, $end_col];
                       $self->scr_xor_span(@{$self->{highlight}}, urxvt::RS_RVid);
                       $self->{pty_ev_events} = $self->pty_ev_events(urxvt::EV_NONE);
                       $self->enable(refresh_begin => \&clear_highlight);


### PR DESCRIPTION
Looks like that extensions callback model was changed in urxvt 9.21. `on_user_command` marked as deprecated and `on_action` is introduced.

Also, I've found that now `on_key_press` will come always before `on_action`/`on_user_command`, so completion will not go further than first match (due ASCII keycode check). Fixed via dirty trick on checking `$event->{'state'}` on modifier-key (except SHIFT, which is state 1).

Also, in 9.21 plugin can "hang" (not actually) terminal if user will hold autocompletion key. It happens due race condition between `clear_highlight` and `enable(refresh_begin => ` code (they both modify `pty_ev_events`, and sometimes in wrong order). Looks like fixed by additional restore step of `pty_ev_events` just before setting it to `urxvt::EV_NONE`.

Tested also with pre-9.21 version.