### PR TITLE
insert backspace via tt_write

### DIFF
--- a/autocomplete-ALL-the-things
+++ b/autocomplete-ALL-the-things
@@ -237,7 +237,7 @@ sub replace_text {
     my ($self, $current_text, $replacement) = @_;
 
     # "press" backspace to erase the text; probably not portable
-    $self->tt_paste($self->locale_encode(chr(0x7F) x length $current_text));
+    $self->tt_write($self->locale_encode(chr(0x7F) x length $current_text));
 
     # print out the replacement
     $self->tt_write($self->locale_encode($replacement));


### PR DESCRIPTION
For whatever reason after routine system update autocomplete-all-the-things starts to insert special character `^?`. After changing `tt_paste` to `tt_write` it works as expected. `man urxvtperls` says, that `tt_paste` will bracket data with control sequences, anyway.