### PR TITLE
do not leave completion on super+<key> press

### DIFF
--- a/autocomplete-ALL-the-things
+++ b/autocomplete-ALL-the-things
@@ -159,7 +159,8 @@ sub conditional_leave {
 
     my $modifier_mask = $ControlMask
                       | $Mod1Mask  # Alt
-                      | $Mod5Mask; # AltGr
+                      | $Mod5Mask  # AltGr
+                      | $Mod4Mask; # Super
 
     # Stop the completion mode only when either a alphanumeric key is
     # pressed (regardless of any modifiers) or a printable key is


### PR DESCRIPTION
I have mapping <kbd>Super</kbd>+<kbd>Tab</kbd>, which cycle through completions, but it gets stuck on first one because of `conditional_leave` code.